### PR TITLE
Stub to participate in auction

### DIFF
--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -10,8 +10,9 @@ contract("DxMgnPool", (accounts) => {
     it("adds a particpation", async () => {
       const depositTokenMock = await MockContract.new()
       const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address)
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, 0)
 
       await depositTokenMock.givenAnyReturnBool(true)
       await dxMock.givenAnyReturnUint(42)
@@ -29,8 +30,9 @@ contract("DxMgnPool", (accounts) => {
     it("fails if transfer fails", async () => {
       const depositTokenMock = await MockContract.new()
       const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address)
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, 0)
 
       await depositTokenMock.givenAnyReturnBool(false)
       await dxMock.givenAnyReturnUint(42)
@@ -40,8 +42,9 @@ contract("DxMgnPool", (accounts) => {
     it("address can deposit multiple times", async() => {
       const depositTokenMock = await MockContract.new()
       const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address)
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, 0)
 
       await depositTokenMock.givenAnyReturnBool(true)
       await dxMock.givenAnyReturnUint(42)
@@ -56,6 +59,73 @@ contract("DxMgnPool", (accounts) => {
 
       assert.equal(await instance.totalDeposit.call(), 30)
       assert.equal(await instance.totalPoolShares.call(), 30)
+    })
+  })
+
+  describe("participateInAuction()", () => {
+    it("updates auctionCount and cummulative shares", async() => {
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
+      
+      await depositTokenMock.givenAnyReturnBool(true)
+      await dxMock.givenAnyReturnUint(42)
+
+      await instance.deposit(10)
+      await instance.participateInAuction()
+
+      assert.equal(await instance.auctionCount.call(), 1)
+      assert.equal(await instance.totalPoolSharesCummulative.call(), 10)
+    })
+    it("fails if pooling period is over", async() => {
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+      const poolingEndBlock = (await web3.eth.getBlockNumber()) - 1
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
+      
+      await truffleAssert.reverts(instance.participateInAuction(), "Pooling period is over")
+    })
+    it("cannot participate twice with same auction id", async() => {
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
+      
+      await depositTokenMock.givenAnyReturnBool(true)
+      await dxMock.givenAnyReturnUint(42)
+
+      await instance.deposit(10)
+      await instance.participateInAuction()
+
+      await truffleAssert.reverts(instance.participateInAuction(),  "Has to wait for new auction to start")
+    })
+    it("can participate in consecutive auction", async() => {
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
+      
+      await depositTokenMock.givenAnyReturnBool(true)
+      await dxMock.givenAnyReturnUint(42)
+
+      await instance.deposit(10)
+      await instance.participateInAuction()
+
+      await instance.deposit(20)
+      await dxMock.givenAnyReturnUint(43)
+      await instance.participateInAuction()
+
+      assert.equal(await instance.auctionCount.call(), 2)
+      assert.equal(await instance.totalPoolSharesCummulative.call(), 40) // 2 * 10 from first deposit + 1 * 20 from second
     })
   })
 })


### PR DESCRIPTION
In order to build withdrawels, I need to simulate the participation in some auctions (in particular the incrementation of cummulative pool shares and auction counts).

This diff adds a stub method for that, which will eventually call into the DutchXTrader contract.

Unit test coverage 100%