### PR TITLE
Replacing time measurements from block number to block time

### DIFF
--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -35,21 +35,21 @@ contract DxMgnPool is Ownable {
     TokenFRT public mgnToken;
     IDutchExchange public dx;
 
-    uint public poolingPeriodEndBlockNumber;
+    uint public poolingPeriodEndTime;
 
     constructor (
         ERC20 _depositToken, 
         ERC20 _secondaryToken, 
         TokenFRT _mgnToken, 
         IDutchExchange _dx,
-        uint _poolingPeriodEndBlockNumber
+        uint _poolingTimeSeconds
     ) public Ownable()
     {
         depositToken = _depositToken;
         secondaryToken = _secondaryToken;
         mgnToken = _mgnToken;
         dx = _dx;
-        poolingPeriodEndBlockNumber = _poolingPeriodEndBlockNumber;
+        poolingPeriodEndTime = now + _poolingTimeSeconds;
     }
 
     /**
@@ -186,7 +186,7 @@ contract DxMgnPool is Ownable {
     }
 
     function currentState() private view returns (State) {
-        if (block.number >= poolingPeriodEndBlockNumber && isDepositTokenTurn()) {
+        if (now >= poolingPeriodEndTime && isDepositTokenTurn()) {
             return totalMgn > 0 ? State.MgnUnlocked : State.PoolingEnded;
         }
         return State.Pooling;

--- a/migrations/4_deploy_Pool.js
+++ b/migrations/4_deploy_Pool.js
@@ -30,12 +30,9 @@ module.exports = async (deployer, network) => { // eslint-disable-line no-unused
     dxProxy = await DxProxy.deployed()
     dxMGN = await DxMGN.deployed()
   }
-  //To be changed to time: time is better since all the other dao stuff also depends on timestamps
-  //const now = new Date()
-  // const endingTradingTimestamp =  new Date(now.getTime() + TRADING_PERIOD_IN_HOURS * 60 * 60 * 1000).getTime() 
-  const poolingEndBlock = 3829876 + 10000
+  const poolingTime = 3 * 60 * 60 * 24 // 3 days for testing
   
   //console.log("abi encoded constructor parameters are: ", web3.eth.abi.encodeParameters(['address', 'address', 'address', 'address', 'uint256'], [etherToken.address, tokenGNO.address, dxMGN.address, dxProxy.address, poolingEndBlock]))
   
-  await deployer.deploy(Coordinator, etherToken.address, tokenGNO.address, dxMGN.address, dxProxy.address, poolingEndBlock)
+  await deployer.deploy(Coordinator, etherToken.address, tokenGNO.address, dxMGN.address, dxProxy.address, poolingTime)
 }

--- a/test/dx_e2e.js
+++ b/test/dx_e2e.js
@@ -11,7 +11,7 @@ const DXProxy = artifacts.require("DutchExchangeProxy")
 const EtherToken = artifacts.require("EtherToken")
 
 const truffleAssert = require("truffle-assertions")
-const { waitForNBlocks, timestamp, increaseTimeBy } = require("./utilities")
+const { timestamp, increaseTimeBy } = require("./utilities")
 const BN = web3.utils.BN
 
 
@@ -23,9 +23,9 @@ contract("e2e - tests", (accounts) => {
     const dx = await DX.at(dxProxy.address)
     const mgnToken = await TokenFRT.at(await dx.frtToken.call())
     const token_1 = await EtherToken.at(await dx.ethToken.call())
-    const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+    const poolingTime = (60 * 60 * 6) + 100
 
-    const coordinator = await Coordinator.new(token_1.address, token_2.address, mgnToken.address, dx.address, poolingEndBlock)
+    const coordinator = await Coordinator.new(token_1.address, token_2.address, mgnToken.address, dx.address, poolingTime)
 
     const instance1 = await DxMgnPool.at(await coordinator.dxMgnPool1.call())
     const instance2 = await DxMgnPool.at(await coordinator.dxMgnPool2.call())
@@ -110,7 +110,7 @@ contract("e2e - tests", (accounts) => {
     console.log("got third auction finished")
 
     // end pool trading period:
-    await waitForNBlocks(100, accounts[0])
+    await increaseTimeBy(100)
 
     await instance1.triggerMGNunlockAndClaimTokens()
     await instance2.triggerMGNunlockAndClaimTokens()
@@ -147,9 +147,9 @@ contract("e2e - tests", (accounts) => {
     const dx = await DX.at(dxProxy.address)
     const mgnToken = await TokenFRT.at(await dx.frtToken.call())
     const token_1 = await EtherToken.at(await dx.ethToken.call())
-    const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+    const poolingTime = (60 * 60 * 6) + 100
 
-    const coordinator = await Coordinator.new(token_1.address, token_2.address, mgnToken.address, dx.address, poolingEndBlock)
+    const coordinator = await Coordinator.new(token_1.address, token_2.address, mgnToken.address, dx.address, poolingTime)
 
     const instance1 = await DxMgnPool.at(await coordinator.dxMgnPool1.call())
 
@@ -231,7 +231,7 @@ contract("e2e - tests", (accounts) => {
     // console.log("got third auction finished")
 
     // // end pool trading period:
-    // await waitForNBlocks(100, accounts[0])
+    // await increaseTimeBy(100)
 
     // await instance1.triggerMGNunlockAndClaimTokens()
 

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -147,7 +147,7 @@ contract("DxMgnPool", (accounts) => {
       const poolingEndBlock = 1
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
-      await increaseTimeBy(100)
+      await increaseTimeBy(100, web3)
       await truffleAssert.reverts(instance.participateInAuction(), "Pooling period is over")
     })
     it("pooling period ends only after even amount of autcions", async() => {
@@ -386,7 +386,7 @@ contract("DxMgnPool", (accounts) => {
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
 
-      await increaseTimeBy(100)
+      await increaseTimeBy(100, web3)
       await instance.triggerMGNunlockAndClaimTokens()
 
       const withdraw = dx.contract.methods.withdraw(depositTokenMock.address, 42).encodeABI()

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -8,7 +8,7 @@ const ERC20 = artifacts.require("ERC20")
 const MockContract = artifacts.require("MockContract")
 
 const truffleAssert = require("truffle-assertions")
-const { waitForNBlocks } = require("./utilities")
+const { increaseTimeBy } = require("./utilities")
 
 contract("DxMgnPool", (accounts) => {
   describe("deposit()", () => {
@@ -38,7 +38,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
 
@@ -103,7 +103,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -123,7 +123,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -144,9 +144,10 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) - 1
+      const poolingEndBlock = 1
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
+      await increaseTimeBy(100)
       await truffleAssert.reverts(instance.participateInAuction(), "Pooling period is over")
     })
     it("pooling period ends only after even amount of autcions", async() => {
@@ -156,7 +157,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -170,7 +171,7 @@ contract("DxMgnPool", (accounts) => {
 
       await instance.deposit(10)
       await instance.participateInAuction()
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
 
       await dxMock.givenAnyReturnUint(2)
       tupleResponse = (abi.rawEncode(["uint", "uint"], [2, 0]))
@@ -188,7 +189,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -211,7 +212,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -246,7 +247,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
@@ -259,7 +260,7 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(postSellOrder, reponseType)
 
       await instance.deposit(10)
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
       await instance.withdrawDeposit()
 
       const depositTransfer = token.contract.methods.transfer(accounts[0], 10).encodeABI()
@@ -273,7 +274,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
@@ -287,7 +288,7 @@ contract("DxMgnPool", (accounts) => {
       
       await instance.deposit(10)
       await instance.deposit(10)
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
       await instance.withdrawDeposit()
 
       const depositTransfer = token.contract.methods.transfer(accounts[0], 20).encodeABI()
@@ -301,7 +302,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
@@ -315,7 +316,7 @@ contract("DxMgnPool", (accounts) => {
 
       await instance.deposit(10)
 
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
       await depositTokenMock.givenAnyReturnBool(true)
 
       await instance.withdrawDeposit()
@@ -332,7 +333,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
   
       await truffleAssert.reverts(instance.withdrawDeposit(), "Pooling period is not over, yet")
@@ -345,7 +346,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
@@ -359,7 +360,7 @@ contract("DxMgnPool", (accounts) => {
 
       await instance.deposit(10)
 
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
 
       await depositTokenMock.givenAnyReturnBool(false)
       await truffleAssert.reverts(instance.withdrawDeposit(), "Failed to transfer deposit")
@@ -374,7 +375,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) - 1
+      const poolingEndBlock = 1
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
 
       await dxMock.givenAnyReturnUint(42)
@@ -385,6 +386,7 @@ contract("DxMgnPool", (accounts) => {
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
 
+      await increaseTimeBy(100)
       await instance.triggerMGNunlockAndClaimTokens()
 
       const withdraw = dx.contract.methods.withdraw(depositTokenMock.address, 42).encodeABI()
@@ -395,7 +397,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
 
       await truffleAssert.reverts(instance.triggerMGNunlockAndClaimTokens(), "Pooling period is not yet over.")
@@ -408,7 +410,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
@@ -429,7 +431,7 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(postSellOrder, abi.rawEncode(["uint", "uint"], [3, 0]))
       await instance.participateInAuction()
       
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
 
       await truffleAssert.reverts(instance.triggerMGNunlockAndClaimTokens(), "Last auction is still running")
     })
@@ -440,7 +442,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
 
       await truffleAssert.reverts(instance.withdrawUnlockedMagnoliaFromDx(), "Pooling period is not yet over.")
@@ -455,7 +457,7 @@ contract("DxMgnPool", (accounts) => {
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
       const dx = await DutchExchange.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -475,7 +477,7 @@ contract("DxMgnPool", (accounts) => {
       await instance.participateInAuction()
       await instance.participateInAuction()
 
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
       await instance.withdrawUnlockedMagnoliaFromDx()
       
       assert.equal(await instance.totalMgn.call(), 100)
@@ -491,7 +493,7 @@ contract("DxMgnPool", (accounts) => {
       const secondaryTokenMock = await MockContract.new()
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) - 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
 
       await truffleAssert.reverts(instance.withdrawMagnolia(), "MGN has not been unlocked, yet")
@@ -502,7 +504,7 @@ contract("DxMgnPool", (accounts) => {
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
       const dx = await DutchExchange.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -519,7 +521,7 @@ contract("DxMgnPool", (accounts) => {
       await instance.deposit(10)
       await instance.participateInAuction()
       await instance.participateInAuction()
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
       await instance.withdrawUnlockedMagnoliaFromDx()
       
       assert.equal(await instance.totalMgn.call(), 100)
@@ -534,7 +536,7 @@ contract("DxMgnPool", (accounts) => {
       const mgnTokenMock = await MockContract.new()
       const dxMock = await MockContract.new()
       const dx = await DutchExchange.new()
-      const poolingEndBlock = (await web3.eth.getBlockNumber()) + 100
+      const poolingEndBlock = 100
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, mgnTokenMock.address, dxMock.address, poolingEndBlock)
       
       await depositTokenMock.givenAnyReturnBool(true)
@@ -554,7 +556,7 @@ contract("DxMgnPool", (accounts) => {
       await instance.participateInAuction()
       await instance.participateInAuction()
 
-      await waitForNBlocks(100, accounts[0])
+      await increaseTimeBy(100)
       await instance.withdrawUnlockedMagnoliaFromDx()
       await instance.withdrawDeposit()
 

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,9 +1,3 @@
-const waitForNBlocks = async function (numBlocks, authority) {
-  for (let i = 0; i < numBlocks; i++) {
-    await web3.eth.sendTransaction({ from: authority, "to": authority, value: 1 })
-  }
-}
-
 const timestamp = async (block = 'latest') => {
   const b = await web3.eth.getBlock(block)
   return b.timestamp
@@ -52,6 +46,5 @@ const increaseTimeBy = async (seconds) => {
 
 module.exports = {
   increaseTimeBy,
-  waitForNBlocks,
   timestamp,
 }


### PR DESCRIPTION
Since difficulty bomb might make it hard to predict the final block number we want to be pooling on and since time measures for dx are already based on timestamps instead of blocktime, this is likely a good idea.

Includes updates to migration scripts and simulation