### PR TITLE
Accounts for totalPoolShareCum. only in the depositTokenTurns

### DIFF
--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -109,10 +109,13 @@ contract DxMgnPool is Ownable {
 
         (address sellToken, address buyToken) = buyAndSellToken();
         uint depositAmount = depositToken.balanceOf(address(this));
-        if (isDepositTokenTurn() && depositAmount > 0) {
-            //depositing new tokens
-            depositToken.approve(address(dx), depositAmount);
-            dx.deposit(address(depositToken), depositAmount);
+        if (isDepositTokenTurn()) {
+            totalPoolSharesCummulative += 2 * totalPoolShares;
+            if( depositAmount > 0){
+                //depositing new tokens
+                depositToken.approve(address(dx), depositAmount);
+                dx.deposit(address(depositToken), depositAmount);
+            }
         }
         // Don't revert if we can't claimSellerFunds
         address(dx).call(abi.encodeWithSignature("claimSellerFunds(address,address,address,uint256)", buyToken, sellToken, address(this), lastParticipatedAuctionIndex));
@@ -124,7 +127,6 @@ contract DxMgnPool is Ownable {
 
         (lastParticipatedAuctionIndex, ) = dx.postSellOrder(sellToken, buyToken, 0, amount);
         auctionCount += 1;
-        totalPoolSharesCummulative += totalPoolShares;
     }
 
     function triggerMGNunlockAndClaimTokens() public {

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -157,7 +157,7 @@ contract("DxMgnPool", (accounts) => {
       await instance.participateInAuction()
 
       assert.equal(await instance.auctionCount.call(), 1)
-      assert.equal(await instance.totalPoolSharesCummulative.call(), 10)
+      assert.equal(await instance.totalPoolSharesCummulative.call(), 20)
     })
     it("fails if pooling period is over", async () => {
       const depositTokenMock = await MockContract.new()
@@ -254,7 +254,7 @@ contract("DxMgnPool", (accounts) => {
       await instance.participateInAuction()
 
       assert.equal(await instance.auctionCount.call(), 2)
-      assert.equal(await instance.totalPoolSharesCummulative.call(), 40) // 2 * 10 from first deposit + 1 * 20 from second
+      assert.equal(await instance.totalPoolSharesCummulative.call(), 20) // just 2*10 from first deposit
     })
   })
 


### PR DESCRIPTION
we actually need the 2x totalDeposits,

as otherwise, we would have to change the calculateClaimableMgn or auctionCounting