### PR TITLE
[Easy] Adjust withdraw condition in triggerMGNunlockAndClaimTokens

### DIFF
--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -142,7 +142,7 @@ contract DxMgnPool is Ownable {
 
         uint amountOfFundsInDX = dx.balances(address(depositToken), address(this));
         totalDeposit = amountOfFundsInDX + depositToken.balanceOf(address(this));
-        if(totalDeposit > 0){
+        if(amountOfFundsInDX > 0){
             dx.withdraw(address(depositToken), amountOfFundsInDX);
         }
         currentState = State.DepositWithdrawnFromDx;


### PR DESCRIPTION
We should only withdraw if the amountOfFundsInDx is > 0, not the total deposit. If totalDeposit was > 0 and amountOfFundsInDX, we could get stuck since dx throws whenever we try to withdraw 0 (https://github.com/gnosis/dx-contracts/blob/master/contracts/DutchExchange.sol#L350).

fixes issue #44 