### PR TITLE
#47 Send Mail on cron Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ COPY contracts contracts
 
 # Compile necesary contracts for app and cleanup unnecesary files
 RUN apk add --update --no-cache --virtual build-dependencies git python make bash g++ ca-certificates && \
-    apk add --no-cache git
+    apk add --no-cache git mailx postfix
 
 COPY . .
 COPY tasks/cron-task /etc/crontabs/root
 
 RUN chmod +x tasks/participate.sh
+RUN chmod +x tasks/entry.sh
 
 RUN npm install
 
@@ -31,4 +32,6 @@ RUN npm run networks-inject
 RUN crontab /etc/crontabs/root
 
 # Run the command on container startup
-CMD [ "sh", "-c", "echo 'Starting container service' && /usr/sbin/crond -f" ]
+# CMD [ "sh", "-c", "echo 'Starting container service' && /usr/sbin/crond -f" ]
+
+CMD [ "sh", "-c", "tasks/entry.sh" ]

--- a/tasks/entry.sh
+++ b/tasks/entry.sh
@@ -1,0 +1,8 @@
+echo 'Starting container service'
+
+# Postfix minimal configuration
+postconf "smtputf8_enable = no"
+mkfifo /var/spool/postfix/public/pickup
+postfix start
+
+/usr/sbin/crond -f

--- a/tasks/participate.sh
+++ b/tasks/participate.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
+MAIL_TO=ben@gnosis.pm
 
 cd /usr/src/app/
-./node_modules/.bin/truffle exec scripts/participateInAuction.js --network $NETWORK
+./node_modules/.bin/truffle exec scripts/participateInAuction.js --network $NETWORK > bot_log.txt
 
-echo "hello world" | mail -s "a subject" ben@gnosis.pm
+EXIT_STATUS=$?
+echo EXIT_STATUS
+cat bot_log.txt
+
+if [ $EXIT_STATUS -ne 0 ];then
+    echo "Sending Error message to ${MAIL_TO}"
+    cat bot_log.txt | mail -s "MGN Pool Error" ${MAIL_TO}
+fi;

--- a/tasks/participate.sh
+++ b/tasks/participate.sh
@@ -2,3 +2,5 @@
 
 cd /usr/src/app/
 ./node_modules/.bin/truffle exec scripts/participateInAuction.js --network $NETWORK
+
+echo "hello world" | mail -s "a subject" ben@gnosis.pm

--- a/tasks/participate.sh
+++ b/tasks/participate.sh
@@ -5,7 +5,6 @@ cd /usr/src/app/
 ./node_modules/.bin/truffle exec scripts/participateInAuction.js --network $NETWORK > bot_log.txt
 
 EXIT_STATUS=$?
-echo EXIT_STATUS
 cat bot_log.txt
 
 if [ $EXIT_STATUS -ne 0 ];then


### PR DESCRIPTION
This does not need to be merged at the moment as @luarx has already configured a Slack messages to be sent (to the channel #alerts-dx-mgn-pool) with all stderr content.

However this also works and sends an email to me with stderr. This is only a backup solution and probably wouldn't work with the existing solution if merged.
