### PR TITLE
adding inteface for transaction batching

### DIFF
--- a/contracts/Coordinator.sol
+++ b/contracts/Coordinator.sol
@@ -30,4 +30,11 @@ contract Coordinator {
         return auctionIndex > dxMgnPool1.lastParticipatedAuctionIndex() && dxMgnPool1.currentState() == DxMgnPool.State.Pooling;
     }
 
+    function withdrawMGNandDepositsFromBothPools() public {
+        address(dxMgnPool1).delegatecall(abi.encodeWithSignature("withdrawDeposit()"));
+        address(dxMgnPool1).delegatecall(abi.encodeWithSignature("withdrawMagnolia()"));
+
+        address(dxMgnPool2).delegatecall(abi.encodeWithSignature("withdrawDeposit()"));
+        address(dxMgnPool2).delegatecall(abi.encodeWithSignature("withdrawMagnolia()"));
+    }
 }

--- a/test/dx_coordinator.js
+++ b/test/dx_coordinator.js
@@ -1,6 +1,10 @@
 const DxMgnPool = artifacts.require("DxMgnPool")
 const Coordinator = artifacts.require("Coordinator")
 const DutchExchange = artifacts.require("DutchExchange")
+const TokenFRT = artifacts.require("TokenFRT")
+const { increaseTimeBy } = require("./utilities")
+
+
 
 const abi = require("ethereumjs-abi")
 
@@ -97,6 +101,58 @@ contract("Coordinator", (accounts) => {
       await dxMock.givenAnyReturnUint(0)
 
       assert.equal(await coordinator.canParticipate(), false)
+    })
+  })
+  describe("withdrawMGNandDepositsFromBothPools()", () => {
+    it("checks that all withdrawals are processed correctly", async () => {
+      const dx = await DutchExchange.new()
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+      const mgn = await TokenFRT.new()
+      
+      const poolingTime = 1000
+      const frtToken = dx.contract.methods.frtToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      await depositTokenMock.givenAnyReturnBool(true)
+      await secondaryTokenMock.givenAnyReturnBool(true)
+
+      await dxMock.givenAnyReturnUint(10)
+      const postSellOrder = dx.contract.methods.postSellOrder(accounts[0], accounts[0], 0, 0).encodeABI()
+      const tupleResponse = (abi.rawEncode(["uint", "uint"], [2, 0]))
+      await dxMock.givenMethodReturn(postSellOrder, tupleResponse)
+      const claimSellerFunds = dx.contract.methods.claimSellerFunds(accounts[0], accounts[0], accounts[0], 0).encodeABI()
+      await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
+      await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+      
+      const balanceOf = mgn.contract.methods.balanceOf(accounts[0]).encodeABI()
+      await mgnTokenMock.givenAnyReturnBool(true)
+      await mgnTokenMock.givenMethodReturnUint(balanceOf, 100)
+
+      const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
+
+      const instance1 = await DxMgnPool.at(await coordinator.dxMgnPool1.call())
+      const instance2 = await DxMgnPool.at(await coordinator.dxMgnPool2.call())
+
+      await instance1.deposit(10)
+      await instance2.deposit(10)
+
+      await increaseTimeBy(poolingTime, web3)
+
+      await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
+      const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
+      await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
+      await depositTokenMock.givenMethodReturnUint(balanceOf, 2)
+      
+      await instance1.triggerMGNunlockAndClaimTokens()
+      await instance2.triggerMGNunlockAndClaimTokens()
+      await increaseTimeBy(24*60*60+12, web3)
+      await instance1.withdrawUnlockedMagnoliaFromDx()
+      await instance2.withdrawUnlockedMagnoliaFromDx()
+      
+      await coordinator.withdrawMGNandDepositsFromBothPools()
     })
   })
 })


### PR DESCRIPTION
- adds an interface for david for easy transaction batching.
- adds necessary tests. Unfortunately, better testing is not possible within the mock contract as safeTransferFrom is only internal transaction and I can not count its invocations.


I am aware that the coordinator contract is not the perfect place to expose this interface. But it was very handy, as this contract is aware of all contracts, from which we are withdrawing.
