### PR TITLE
Update pool state before checking current.

### DIFF
--- a/contracts/Coordinator.sol
+++ b/contracts/Coordinator.sol
@@ -21,7 +21,7 @@ contract Coordinator {
         dxMgnPool2.participateInAuction();
     }
 
-    function canParticipate() public view returns (bool) {
+    function canParticipate() public returns (bool) {
         uint auctionIndex = dxMgnPool1.dx().getAuctionIndex(
             address(dxMgnPool1.depositToken()),
             address(dxMgnPool1.secondaryToken())

--- a/contracts/Coordinator.sol
+++ b/contracts/Coordinator.sol
@@ -26,6 +26,8 @@ contract Coordinator {
             address(dxMgnPool1.depositToken()),
             address(dxMgnPool1.secondaryToken())
         );
+        // update the state before checking the currentState
+        dxMgnPool1.checkForStateUpdate();
         // Since both auctions start at the same time, it suffices to check one.
         return auctionIndex > dxMgnPool1.lastParticipatedAuctionIndex() && dxMgnPool1.currentState() == DxMgnPool.State.Pooling;
     }

--- a/scripts/participateInAuction.js
+++ b/scripts/participateInAuction.js
@@ -11,7 +11,8 @@ module.exports = async (callback) => {
   try {
     const coordinator = await Coordinator.deployed()
     console.log("Coordinator deployed at %s", coordinator.address)
-    if (await coordinator.canParticipate()) {
+
+    if (await coordinator.canParticipate.call() {
       let fastPrice = 20000000000  // 20 GWei
       try {
         fastPrice = (await GasStation.estimateGas(url)).fast

--- a/test/dx_coordinator.js
+++ b/test/dx_coordinator.js
@@ -65,7 +65,7 @@ contract("Coordinator", (accounts) => {
       const postSellOrderResponse = (abi.rawEncode(["uint", "uint"], [2, 0]))
       await dxMock.givenMethodReturn(postSellOrder, postSellOrderResponse)
 
-      assert.equal(await coordinator.canParticipate(), true)
+      assert.equal(await coordinator.canParticipate.call(), true)
     })
 
     it("False - no auction scheduled", async () => {
@@ -83,7 +83,7 @@ contract("Coordinator", (accounts) => {
 
       await dxMock.givenAnyReturnUint(0)
 
-      assert.equal(await coordinator.canParticipate(), false)
+      assert.equal(await coordinator.canParticipate.call(), false)
     })
     it("False - not the right state", async () => {
       const dx = await DutchExchange.new()
@@ -100,7 +100,7 @@ contract("Coordinator", (accounts) => {
 
       await dxMock.givenAnyReturnUint(0)
 
-      assert.equal(await coordinator.canParticipate(), false)
+      assert.equal(await coordinator.canParticipate.call(), false)
     })
   })
   describe("withdrawMGNandDepositsFromBothPools()", () => {


### PR DESCRIPTION
Alternatively, the currentState could check for update before returning (but this would result in changed to the pool contract rather than the coordinator). This is easier to audit.