### PR TITLE
storing the withdrawn variable per address, not per deposit

### DIFF
--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -440,13 +440,11 @@ contract("DxMgnPool", (accounts) => {
       await instance.triggerMGNunlockAndClaimTokens()
       
       await instance.withdrawDeposit()
-      await instance.withdrawDeposit()
 
       const depositTransfer = token.contract.methods.transfer(accounts[0], 10).encodeABI()
       assert.equal(await depositTokenMock.invocationCountForCalldata.call(depositTransfer), 1)
 
-      const emptyTransfer = token.contract.methods.transfer(accounts[0], 0).encodeABI()
-      assert.equal(await depositTokenMock.invocationCountForCalldata.call(emptyTransfer), 1)
+      await truffleAssert.reverts(instance.withdrawDeposit(), "sender has already withdrawn funds")
     })
     it("cannot withdraw while pooling is running", async () => {
       const dx = await DutchExchange.new()


### PR DESCRIPTION
This PR contains the code changes for storing the withdrawn attribute no longer per deposit, but per address.
This was suggested by the auditors, as only all deposits can be withdrawn at once. It is not possible to withdraw parts of the deposits and hence we do not need to store it per deposit

implemented as feedback from auditors suggested....