### PR TITLE
updateAndGetState + getAllClaimableMgnAndDeposits getters

### DIFF
--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -168,6 +168,13 @@ contract DxMgnPool is Ownable {
         }
     }
 
+    /// @dev updates state and returns val
+    function updateAndGetCurrentState() public returns(State) {
+        checkForStateUpdate();
+
+        return currentState;
+    }
+
     /**
      * Public View Functions
      */
@@ -198,6 +205,20 @@ contract DxMgnPool is Ownable {
         } else {
             return (address(secondaryToken), address(depositToken)); 
         }
+    }
+
+    function getAllClaimableMgnAndDeposits(address userAddress) external view returns(uint[] memory, uint[] memory) {
+        uint length = participationsByAddress[userAddress].length;
+
+        uint[] memory allUserClaimableMgn = new uint[](length);
+        uint[] memory allUserClaimableDeposit = new uint[](length);
+
+        for (uint i = 0; i < length; i++) {
+            allUserClaimableMgn[i] = calculateClaimableMgn(participationsByAddress[userAddress][i]);
+            allUserClaimableDeposit[i] = calculateClaimableDeposit(participationsByAddress[userAddress][i]);
+        }
+
+        return (allUserClaimableMgn, allUserClaimableDeposit);
     }
 
     /**

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -872,4 +872,47 @@ contract("DxMgnPool", (accounts) => {
       await truffleAssert.reverts(instance.withdrawMagnolia())
     })
   })
+  describe("getAllClaimableMgnAndDeposits() view function", () => {
+    it("returns values correctly", async () => {
+      const dx = await DutchExchange.new()
+      
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+    
+      await depositTokenMock.givenAnyReturnBool(true)
+      const frtToken = dx.contract.methods.frtToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+      await dxMock.givenAnyReturnUint(42)
+      
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
+      
+      const { "0": claimableMgn, "1": claimableDeposits } = await instance.getAllClaimableMgnAndDeposits.call(accounts[0])
+
+      assert.equal(claimableMgn.length, 0, "ClaimableMGN return array must be empty aka 0 length")
+      assert.equal(claimableDeposits.length, 0, "claimableDeposits return array must be empty aka 0 length")
+    })
+  })
+  describe("updateAndGetCurrentState()", () => {
+    it("returns values correctly", async () => {
+      const dx = await DutchExchange.new()
+      
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+    
+      await depositTokenMock.givenAnyReturnBool(true)
+      const frtToken = dx.contract.methods.frtToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+      await dxMock.givenAnyReturnUint(42)
+      
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
+      
+      const state = await instance.updateAndGetCurrentState.call()
+      
+      assert(state, state.eq(web3.utils.toBN(0)), "Current state === 0 aka Pooling")
+    })
+  })
 })


### PR DESCRIPTION
To test:
```
npx truffle console
migrate --reset
coord = await Coordinator.deployed()
dx1Add = await coord.dxMgnPool1.call()
dxMP1 = await DxMgnPool.at(dx1Add)
const accts = await web3.eth.getAccounts() // can't destructure promises in truffle :cry: 
const [main] = accts

await dxMP1.getAllClaimableMgnAndDeposits.call(main)
// Result { '0': [], '1': [] }
```
Reasoning: can't get those values back as set to private internally (Participation as param) - this works for front-end manipulation