### PR TITLE
Adding default return values to calculateClaimabelMgn and calculateClaimableDeposits

### DIFF
--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -217,7 +217,6 @@ contract DxMgnPool is Ownable {
             allUserClaimableMgn[i] = calculateClaimableMgn(participationsByAddress[userAddress][i]);
             allUserClaimableDeposit[i] = calculateClaimableDeposit(participationsByAddress[userAddress][i]);
         }
-
         return (allUserClaimableMgn, allUserClaimableDeposit);
     }
 
@@ -238,12 +237,17 @@ contract DxMgnPool is Ownable {
     }
 
     function calculateClaimableMgn(Participation memory participation) private view returns (uint) {
+        if (totalPoolSharesCummulative == 0) {
+            return totalPoolSharesCummulative;
+        }
         uint duration = auctionCount - participation.startAuctionCount;
         return totalMgn.mul(participation.poolShares).mul(duration) / totalPoolSharesCummulative;
     }
 
     function calculateClaimableDeposit(Participation memory participation) private view returns (uint) {
+        if (totalPoolShares == 0) {
+            return totalPoolShares;
+        }
         return totalDeposit.mul(participation.poolShares) / totalPoolShares;
     }
-
 }


### PR DESCRIPTION
Problem: dividing by either `TotalPoolShare` or `TotalPoolSharesCummulative` when 0 = death :dagger: :skull:  As I am relying on websockets to deliver state payloads to me, this change allows my looping function `getAllClaimableMgnandDeposits` to always return something