### PR TITLE
Require an Infura key for Rinkeby/Mainnet interaction

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,6 @@ if (!privateKey && !mnemonic) {
 }
 
 const infuraProjectId = process.env.INFURA_KEY
-assert(infuraProjectId, "Need an infura ProjectID")
 function truffleConfig ({
   mnemonic = DEFAULT_MNEMONIC,
   privateKey,
@@ -41,6 +40,7 @@ function truffleConfig ({
     console.log('Using private key')
     _getProvider = url => {
       return () => {
+        assert(infuraProjectId, "Need an infura ProjectID")
         return new HDWalletProvider([ privateKey ], url)
       }
     }
@@ -48,6 +48,7 @@ function truffleConfig ({
     console.log(mnemonic === DEFAULT_MNEMONIC ? 'Using default mnemonic' : 'Using custom mnemonic')    
     _getProvider = url => {
       return () => {
+        assert(infuraProjectId, "Need an infura ProjectID")
         return new HDWalletProvider(mnemonic, url)
       }
     }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -15,15 +15,17 @@ if (!privateKey && !mnemonic) {
   mnemonic = DEFAULT_MNEMONIC
 }
 
+const infuraProjectId = process.env.INFURA_KEY
+assert(infuraProjectId, "Need an infura ProjectID")
 function truffleConfig ({
   mnemonic = DEFAULT_MNEMONIC,
   privateKey,
   gasPriceGWei = GAS_PRICE_GWEI,
   gas = GAS_LIMIT,
   optimizedEnabled = true,
-  urlRinkeby = 'https://rinkeby.infura.io/',
-  urlKovan = 'https://kovan.infura.io/',
-  urlMainnet = 'https://mainnet.infura.io',
+  urlRinkeby = 'https://rinkeby.infura.io/v3/' + infuraProjectId,
+  urlKovan = 'https://kovan.infura.io/v3/' + infuraProjectId,
+  urlMainnet = 'https://mainnet.infura.io/v3/' + infuraProjectId,
   urlDevelopment = 'localhost',
   portDevelopment = 8545
 } = {}) {


### PR DESCRIPTION
We have seen a number of errors with our DxMgnPool bot over the last night. These are likely related to not using a Infura access token for interactions (cf. https://blog.infura.io/infura-dashboard-transition-update-c670945a922a)

This PR makes it so that we use the INFURA_KEY environment variable as a token.

I asked @luarx to change the kubernetes setup with a valid key, so that after we merge this PR our bot should automatically use the correct key.