### PR TITLE
compability with OWL token 

### DIFF
--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -11,6 +11,7 @@ import "@daostack/arc/contracts/libs/SafeERC20.sol";
 contract DxMgnPool is Ownable {
     using SafeMath for uint;
 
+    uint constant OWL_ALLOWANCE = 100000000000000000000000000000;
     struct Participation {
         uint startAuctionCount; // how many auction passed when this participation started contributing
         uint poolShares; // number of shares this participation accounts for (absolute)
@@ -34,7 +35,6 @@ contract DxMgnPool is Ownable {
     
     ERC20 public depositToken;
     ERC20 public secondaryToken;
-    ERC20 public owlToken;
     TokenFRT public mgnToken;
     IDutchExchange public dx;
 
@@ -51,7 +51,8 @@ contract DxMgnPool is Ownable {
         secondaryToken = _secondaryToken;
         dx = _dx;
         mgnToken = TokenFRT(dx.frtToken());
-        owlToken = ERC20(dx.owlToken());
+        ERC20 owlToken = ERC20(dx.owlToken());
+        owlToken.approve(address(dx), OWL_ALLOWANCE);
         poolingPeriodEndTime = now + _poolingTimeSeconds;
     }
 
@@ -135,10 +136,6 @@ contract DxMgnPool is Ownable {
 
         (lastParticipatedAuctionIndex, ) = dx.postSellOrder(sellToken, buyToken, 0, amount);
         auctionCount += 1;
-    }
-
-    function setOWLTokenApproval(uint amount) public {
-        owlToken.approve(address(dx), amount);
     }
 
     function triggerMGNunlockAndClaimTokens() public {

--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -11,7 +11,7 @@ import "@daostack/arc/contracts/libs/SafeERC20.sol";
 contract DxMgnPool is Ownable {
     using SafeMath for uint;
 
-    uint constant OWL_ALLOWANCE = 100000000000000000000000000000;
+    uint constant OWL_ALLOWANCE = 1000000000000000000000000000000; //10**30
     struct Participation {
         uint startAuctionCount; // how many auction passed when this participation started contributing
         uint poolShares; // number of shares this participation accounts for (absolute)

--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -51,8 +51,7 @@ contract DxMgnPool is Ownable {
         secondaryToken = _secondaryToken;
         dx = _dx;
         mgnToken = TokenFRT(dx.frtToken());
-        ERC20 owlToken = ERC20(dx.owlToken());
-        owlToken.approve(address(dx), OWL_ALLOWANCE);
+        ERC20(dx.owlToken()).approve(address(dx), OWL_ALLOWANCE);
         poolingPeriodEndTime = now + _poolingTimeSeconds;
     }
 

--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -34,6 +34,7 @@ contract DxMgnPool is Ownable {
     
     ERC20 public depositToken;
     ERC20 public secondaryToken;
+    ERC20 public owlToken;
     TokenFRT public mgnToken;
     IDutchExchange public dx;
 
@@ -50,6 +51,7 @@ contract DxMgnPool is Ownable {
         secondaryToken = _secondaryToken;
         dx = _dx;
         mgnToken = TokenFRT(dx.frtToken());
+        owlToken = ERC20(dx.owlToken());
         poolingPeriodEndTime = now + _poolingTimeSeconds;
     }
 
@@ -133,6 +135,10 @@ contract DxMgnPool is Ownable {
 
         (lastParticipatedAuctionIndex, ) = dx.postSellOrder(sellToken, buyToken, 0, amount);
         auctionCount += 1;
+    }
+
+    function setOWLTokenApproval(address approvalTo, uint amount) public {
+        owlToken.approve(approvalTo, amount);
     }
 
     function triggerMGNunlockAndClaimTokens() public {

--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -137,8 +137,8 @@ contract DxMgnPool is Ownable {
         auctionCount += 1;
     }
 
-    function setOWLTokenApproval(address approvalTo, uint amount) public {
-        owlToken.approve(approvalTo, amount);
+    function setOWLTokenApproval(uint amount) public {
+        owlToken.approve(address(dx), amount);
     }
 
     function triggerMGNunlockAndClaimTokens() public {

--- a/contracts/DxMgnPool.sol
+++ b/contracts/DxMgnPool.sol
@@ -11,7 +11,7 @@ import "@daostack/arc/contracts/libs/SafeERC20.sol";
 contract DxMgnPool is Ownable {
     using SafeMath for uint;
 
-    uint constant OWL_ALLOWANCE = 1000000000000000000000000000000; //10**30
+    uint constant OWL_ALLOWANCE = 10**36; 
     struct Participation {
         uint startAuctionCount; // how many auction passed when this participation started contributing
         uint poolShares; // number of shares this participation accounts for (absolute)

--- a/contracts/interfaces/IDutchExchange.sol
+++ b/contracts/interfaces/IDutchExchange.sol
@@ -13,6 +13,7 @@ contract IDutchExchange {
     function deposit(address tokenAddress, uint amount) public returns (uint);
     function ethToken() public returns(address);
     function frtToken() public returns(address);
+    function owlToken() public returns(address);
     function getAuctionIndex(address token1, address token2) public view returns(uint256);
     function postBuyOrder(address token1, address token2, uint256 auctionIndex, uint256 amount) public returns(uint256);
     function postSellOrder(address token1, address token2, uint256 auctionIndex, uint256 tokensBought) public returns(uint256, uint256);

--- a/test/dx_coordinator.js
+++ b/test/dx_coordinator.js
@@ -3,6 +3,7 @@ const Coordinator = artifacts.require("Coordinator")
 const DutchExchange = artifacts.require("DutchExchange")
 const TokenFRT = artifacts.require("TokenFRT")
 const { increaseTimeBy } = require("./utilities")
+const TokenOWL = artifacts.require("TokenOWL")
 
 
 
@@ -25,6 +26,10 @@ contract("Coordinator", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 
@@ -62,6 +67,10 @@ contract("Coordinator", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 
       await depositTokenMock.givenAnyReturnBool(true)
@@ -90,6 +99,10 @@ contract("Coordinator", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 
       await dxMock.givenAnyReturnUint(0)
@@ -110,6 +123,10 @@ contract("Coordinator", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 

--- a/test/dx_coordinator.js
+++ b/test/dx_coordinator.js
@@ -22,6 +22,9 @@ contract("Coordinator", (accounts) => {
       
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 
@@ -55,6 +58,10 @@ contract("Coordinator", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 
       await depositTokenMock.givenAnyReturnBool(true)
@@ -79,6 +86,10 @@ contract("Coordinator", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 
       await dxMock.givenAnyReturnUint(0)
@@ -95,6 +106,10 @@ contract("Coordinator", (accounts) => {
 
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const coordinator = await Coordinator.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingEndBlock)
 

--- a/test/dx_e2e.js
+++ b/test/dx_e2e.js
@@ -830,7 +830,7 @@ contract("e2e - tests", (accounts) => {
     )
     // ensure that sells go into auction 2, as auction 1 will have been started
     await increaseTimeBy(60 * 60 * 6, web3)
-    await instance1.setOWLTokenApproval(dx.address, mintedOWL);
+    await instance1.setOWLTokenApproval(mintedOWL);
     await owlToken.transfer(instance1.address, mintedOWL);
     assert.equal(await owlToken.allowance(instance1.address, dx.address), mintedOWL, "Tokens allowance is not set correctly")
     const easdf = await PriceOracleInterface.at(await dx.ethUSDOracle());

--- a/test/dx_e2e.js
+++ b/test/dx_e2e.js
@@ -829,9 +829,7 @@ contract("e2e - tests", (accounts) => {
     )
     // ensure that sells go into auction 2, as auction 1 will have been started
     await increaseTimeBy(60 * 60 * 6, web3)
-    await instance1.setOWLTokenApproval(mintedOWL);
     await owlToken.transfer(instance1.address, mintedOWL);
-    assert.equal(await owlToken.allowance(instance1.address, dx.address), mintedOWL, "Tokens allowance is not set correctly")
 
     await coordinator.participateInAuction()
     assert.equal((await dx.sellerBalances.call(token_1.address, token_2.address, 2, instance1.address)).toNumber(), DEPOSIT_1_1*9975/10000)

--- a/test/dx_e2e.js
+++ b/test/dx_e2e.js
@@ -9,7 +9,6 @@ const Coordinator = artifacts.require("Coordinator")
 const DX = artifacts.require("DutchExchange")
 const DXProxy = artifacts.require("DutchExchangeProxy")
 const EtherToken = artifacts.require("EtherToken")
-const PriceOracleInterface = artifacts.require("PriceOracleInterface")
 
 const { 
   waitUntilPriceIsXPercentOfPreviousPrice,

--- a/test/dx_e2e.js
+++ b/test/dx_e2e.js
@@ -832,7 +832,6 @@ contract("e2e - tests", (accounts) => {
     await instance1.setOWLTokenApproval(mintedOWL);
     await owlToken.transfer(instance1.address, mintedOWL);
     assert.equal(await owlToken.allowance(instance1.address, dx.address), mintedOWL, "Tokens allowance is not set correctly")
-    const easdf = await PriceOracleInterface.at(await dx.ethUSDOracle());
 
     await coordinator.participateInAuction()
     assert.equal((await dx.sellerBalances.call(token_1.address, token_2.address, 2, instance1.address)).toNumber(), DEPOSIT_1_1*9975/10000)

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -1133,7 +1133,7 @@ contract("DxMgnPool", (accounts) => {
       const approveToken = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
       await owlTokenMock.givenMethodReturnBool(approveToken, true)
 
-      await instance.setOWLTokenApproval(dxMock.address, 100)
+      await instance.setOWLTokenApproval(100)
 
       const owlApproval = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
       assert.equal(await owlTokenMock.invocationCountForCalldata.call(owlApproval), 1)

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -29,6 +29,9 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
       
@@ -63,6 +66,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -94,6 +101,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 0)
       await truffleAssert.reverts(instance.deposit(10))
     })
@@ -114,6 +125,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await increaseTimeBy(102, web3)
@@ -137,6 +152,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -175,6 +194,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -202,6 +225,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -225,6 +252,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
@@ -255,6 +286,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -294,6 +329,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -323,6 +362,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const getAuctionIndex = dx.contract.methods.getAuctionIndex(accounts[0], accounts[0]).encodeABI()
       
@@ -359,6 +402,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
       
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
       
       await depositTokenMock.givenAnyReturnBool(true) 
@@ -394,6 +441,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -440,6 +491,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -485,6 +540,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -524,6 +583,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await truffleAssert.reverts(instance.withdrawDeposit(), "Funds not yet withdrawn from dx")
     })
@@ -551,6 +614,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -582,6 +649,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
@@ -624,6 +695,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await increaseTimeBy(poolingTime, web3)
       await instance.triggerMGNunlockAndClaimTokens()
@@ -645,6 +720,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
@@ -679,6 +758,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await instance.triggerMGNunlockAndClaimTokens()
@@ -705,6 +788,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
@@ -742,6 +829,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -772,6 +863,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
@@ -805,6 +900,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -854,6 +953,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -895,6 +998,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
       await truffleAssert.reverts(instance.withdrawMagnolia(), "MGN has not been unlocked, yet")
@@ -922,6 +1029,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       await mgnTokenMock.givenAnyReturnUint(100)
       
@@ -967,6 +1078,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const balanceOf = mgnToken.contract.methods.balanceOf(accounts[0]).encodeABI()
       await mgnTokenMock.givenAnyReturnBool(false)
@@ -1014,6 +1129,10 @@ contract("DxMgnPool", (accounts) => {
       const owlTokenMock = await MockContract.new()
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
 
       const balanceOf = mgn.contract.methods.balanceOf(accounts[0]).encodeABI()
       await mgnTokenMock.givenAnyReturnBool(true)
@@ -1064,6 +1183,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       await dxMock.givenAnyReturnUint(42)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
@@ -1091,6 +1214,10 @@ contract("DxMgnPool", (accounts) => {
       const owlToken = dx.contract.methods.owlToken().encodeABI()
       await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
+      const owl = await TokenOWL.new();
+      const owlTokenApproveFunctionality = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(owlTokenApproveFunctionality, true)
+
       await dxMock.givenAnyReturnUint(42)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
@@ -1098,45 +1225,6 @@ contract("DxMgnPool", (accounts) => {
       const state = await instance.updateAndGetCurrentState.call()
       
       assert(state, state.eq(web3.utils.toBN(0)), "Current state === 0 aka Pooling")
-    })
-  })
-  describe("setOWLTokenApproval()", () => {
-    it("checks that owl approval is set after setOWLTokenApproval call", async () => {
-      const token = await ERC20.new()
-      const dx = await DutchExchange.new()
-      const owl = await TokenOWL.new()
-      const depositTokenMock = await MockContract.new()
-      const secondaryTokenMock = await MockContract.new()
-      const mgnTokenMock = await MockContract.new()
-      const dxMock = await MockContract.new()
-      const poolingTime = 1000
-      
-      const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
-      await depositTokenMock.givenAnyReturnBool(true)
-      await depositTokenMock.givenMethodReturnUint(balanceOf, 2)
-      
-      await dxMock.givenAnyReturnUint(2)
-      const postSellOrder = dx.contract.methods.postSellOrder(accounts[0], accounts[0], 0, 0).encodeABI()
-      const tupleResponse = (abi.rawEncode(["uint", "uint"], [2, 0]))
-      await dxMock.givenMethodReturn(postSellOrder, tupleResponse)
-      const claimSellerFunds = dx.contract.methods.claimSellerFunds(accounts[0], accounts[0], accounts[0], 0).encodeABI()
-      await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
-      const frtToken = dx.contract.methods.frtToken().encodeABI()
-      await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
-
-      const owlTokenMock = await MockContract.new()
-      const owlToken = dx.contract.methods.owlToken().encodeABI()
-      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
-
-      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
-      
-      const approveToken = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
-      await owlTokenMock.givenMethodReturnBool(approveToken, true)
-
-      await instance.setOWLTokenApproval(100)
-
-      const owlApproval = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
-      assert.equal(await owlTokenMock.invocationCountForCalldata.call(owlApproval), 1)
     })
   })
 })

--- a/test/dx_mgn_pool.js
+++ b/test/dx_mgn_pool.js
@@ -1,6 +1,7 @@
 const DxMgnPool = artifacts.require("DxMgnPool")
 const DutchExchange = artifacts.require("DutchExchange")
 const TokenFRT = artifacts.require("TokenFRT")
+const TokenOWL = artifacts.require("TokenOWL")
 
 const abi = require("ethereumjs-abi")
 
@@ -24,6 +25,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
       await dxMock.givenAnyReturnUint(42)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
       
@@ -54,6 +59,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -81,6 +90,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
       
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 0)
       await truffleAssert.reverts(instance.deposit(10))
     })
@@ -97,6 +110,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenAnyReturnUint(42)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await increaseTimeBy(102, web3)
@@ -116,7 +133,11 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenAnyReturnUint(42)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
-      
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -150,6 +171,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -173,6 +198,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -192,6 +221,10 @@ contract("DxMgnPool", (accounts) => {
 
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
@@ -218,6 +251,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -253,6 +290,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -278,6 +319,11 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const getAuctionIndex = dx.contract.methods.getAuctionIndex(accounts[0], accounts[0]).encodeABI()
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
@@ -308,6 +354,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
       await dxMock.givenAnyReturnUint(42)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
       
@@ -340,6 +390,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(postSellOrder, reponseType)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -382,6 +436,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -423,6 +481,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -458,6 +520,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await truffleAssert.reverts(instance.withdrawDeposit(), "Funds not yet withdrawn from dx")
     })
@@ -481,6 +547,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(postSellOrder, reponseType)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -508,6 +578,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
@@ -546,6 +620,10 @@ contract("DxMgnPool", (accounts) => {
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
       
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await increaseTimeBy(poolingTime, web3)
       await instance.triggerMGNunlockAndClaimTokens()
@@ -563,6 +641,10 @@ contract("DxMgnPool", (accounts) => {
 
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
@@ -593,6 +675,10 @@ contract("DxMgnPool", (accounts) => {
       
       const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
       await depositTokenMock.givenMethodReturnUint(balanceOf, 2)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       await instance.triggerMGNunlockAndClaimTokens()
@@ -615,6 +701,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturnUint(balances, 0)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const unlockTokens = mgn.contract.methods.unlockTokens().encodeABI()
       await mgnTokenMock.givenMethodReturn(unlockTokens, tupleResponse)
@@ -648,6 +738,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
       await instance.deposit(10)
@@ -674,6 +768,10 @@ contract("DxMgnPool", (accounts) => {
 
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
@@ -703,6 +801,10 @@ contract("DxMgnPool", (accounts) => {
       const balanceOf = mgn.contract.methods.balanceOf(accounts[0]).encodeABI()
       await mgnTokenMock.givenAnyReturnBool(true)
       await mgnTokenMock.givenMethodReturnUint(balanceOf, 100)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -748,6 +850,10 @@ contract("DxMgnPool", (accounts) => {
       const balanceOf = mgn.contract.methods.balanceOf(accounts[0]).encodeABI()
       await mgnTokenMock.givenAnyReturnBool(true)
       await mgnTokenMock.givenMethodReturnUint(balanceOf, 100)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
       
@@ -785,6 +891,10 @@ contract("DxMgnPool", (accounts) => {
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
 
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
 
       await truffleAssert.reverts(instance.withdrawMagnolia(), "MGN has not been unlocked, yet")
@@ -808,6 +918,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       await mgnTokenMock.givenAnyReturnUint(100)
       
@@ -849,6 +963,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const balanceOf = mgnToken.contract.methods.balanceOf(accounts[0]).encodeABI()
       await mgnTokenMock.givenAnyReturnBool(false)
@@ -892,6 +1010,10 @@ contract("DxMgnPool", (accounts) => {
       await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
 
       const balanceOf = mgn.contract.methods.balanceOf(accounts[0]).encodeABI()
       await mgnTokenMock.givenAnyReturnBool(true)
@@ -937,6 +1059,11 @@ contract("DxMgnPool", (accounts) => {
       await depositTokenMock.givenAnyReturnBool(true)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       await dxMock.givenAnyReturnUint(42)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
@@ -959,6 +1086,11 @@ contract("DxMgnPool", (accounts) => {
       await depositTokenMock.givenAnyReturnBool(true)
       const frtToken = dx.contract.methods.frtToken().encodeABI()
       await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
       await dxMock.givenAnyReturnUint(42)
       
       const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, 100)
@@ -966,6 +1098,45 @@ contract("DxMgnPool", (accounts) => {
       const state = await instance.updateAndGetCurrentState.call()
       
       assert(state, state.eq(web3.utils.toBN(0)), "Current state === 0 aka Pooling")
+    })
+  })
+  describe("setOWLTokenApproval()", () => {
+    it("checks that owl approval is set after setOWLTokenApproval call", async () => {
+      const token = await ERC20.new()
+      const dx = await DutchExchange.new()
+      const owl = await TokenOWL.new()
+      const depositTokenMock = await MockContract.new()
+      const secondaryTokenMock = await MockContract.new()
+      const mgnTokenMock = await MockContract.new()
+      const dxMock = await MockContract.new()
+      const poolingTime = 1000
+      
+      const balanceOf = token.contract.methods.balanceOf(accounts[0]).encodeABI()
+      await depositTokenMock.givenAnyReturnBool(true)
+      await depositTokenMock.givenMethodReturnUint(balanceOf, 2)
+      
+      await dxMock.givenAnyReturnUint(2)
+      const postSellOrder = dx.contract.methods.postSellOrder(accounts[0], accounts[0], 0, 0).encodeABI()
+      const tupleResponse = (abi.rawEncode(["uint", "uint"], [2, 0]))
+      await dxMock.givenMethodReturn(postSellOrder, tupleResponse)
+      const claimSellerFunds = dx.contract.methods.claimSellerFunds(accounts[0], accounts[0], accounts[0], 0).encodeABI()
+      await dxMock.givenMethodReturn(claimSellerFunds, tupleResponse)
+      const frtToken = dx.contract.methods.frtToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(frtToken, mgnTokenMock.address)
+
+      const owlTokenMock = await MockContract.new()
+      const owlToken = dx.contract.methods.owlToken().encodeABI()
+      await dxMock.givenMethodReturnAddress(owlToken, owlTokenMock.address)
+
+      const instance = await DxMgnPool.new(depositTokenMock.address, secondaryTokenMock.address, dxMock.address, poolingTime)
+      
+      const approveToken = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      await owlTokenMock.givenMethodReturnBool(approveToken, true)
+
+      await instance.setOWLTokenApproval(dxMock.address, 100)
+
+      const owlApproval = owl.contract.methods.approve(dxMock.address, 100).encodeABI()
+      assert.equal(await owlTokenMock.invocationCountForCalldata.call(owlApproval), 1)
     })
   })
 })


### PR DESCRIPTION
As Anxo requested, here is the PR for adding the compatibility with OWL token.

It allows setting an approval from the pool to the dx, so that the pool can burn owl.

I implemented the function "setOWLTokenApproval" without any ownership check, as we have no owner and this would be much more work. It has the disadvantage that people could reset our OWL allowance. 

If this is really needed, I can add it later, but first want to get it confirmed, before I put all the work into it.